### PR TITLE
Fixes for MSEdge and VSCode path on macos

### DIFF
--- a/src/apps/locateVscode.ts
+++ b/src/apps/locateVscode.ts
@@ -5,6 +5,8 @@ export function locateVSCode(): Promise<string> {
         appName: 'Code',
         linuxWhich: 'code',
         windowsSuffix: '\\Microsoft VS Code\\Code.exe',
-        macOsName: 'Code',
+        macOsName: 'Visual Studio Code',
+        macOsPackageName: 'Visual Studio Code',
+        macOsExecName: 'Electron',
     });
 }

--- a/src/browsers/locateBrowser.test.ts
+++ b/src/browsers/locateBrowser.test.ts
@@ -25,8 +25,8 @@ describe('locating the browser', () => {
             await expect(locateBrowser('edge')).resolves.toMatch(/msedge/i);
             await expect(locateBrowser('msedge')).resolves.toMatch(/msedge/i);
         } else {
-            await expect(locateBrowser('edge')).rejects.toThrow();
-            await expect(locateBrowser('msedge')).rejects.toThrow();
+            await expect(locateBrowser('edge')).resolves.toMatch(/edge/i);
+            await expect(locateBrowser('msedge')).resolves.toMatch(/edge/i);
         }
         expect.assertions(2);
     });
@@ -36,8 +36,8 @@ describe('locating the browser', () => {
             await expect(locateBrowser('ie')).resolves.toMatch(/iexplore/i);
             await expect(locateBrowser('msie')).resolves.toMatch(/iexplore/i);
         } else {
-            await expect(locateBrowser('edge')).rejects.toThrow();
-            await expect(locateBrowser('msedge')).rejects.toThrow();
+            await expect(locateBrowser('edge')).resolves.toMatch(/edge/i);
+            await expect(locateBrowser('msedge')).resolves.toMatch(/edge/i);
         }
         expect.assertions(2);
     });

--- a/src/browsers/locateChrome.test.ts
+++ b/src/browsers/locateChrome.test.ts
@@ -2,7 +2,7 @@ import { locateChrome } from './locateChrome';
 
 describe('locating the Chrome browser', () => {
     it('should locate Chrome browser', async () => {
-        await expect(locateChrome()).resolves.toMatch(/chrome/i);
+        await expect(locateChrome()).resolves.toMatch(/[cC]hrome/i);
         expect.assertions(1);
     });
 });

--- a/src/browsers/locateEdge.test.ts
+++ b/src/browsers/locateEdge.test.ts
@@ -5,7 +5,7 @@ describe('locating the Edge browser', () => {
         if (process.platform === 'win32') {
             await expect(locateEdge()).resolves.toMatch(/msedge/i);
         } else {
-            await expect(locateEdge()).rejects.toThrow();
+            await expect(locateEdge()).resolves.toMatch(/edge/i);
         }
         expect.assertions(1);
     });

--- a/src/browsers/locateEdge.ts
+++ b/src/browsers/locateEdge.ts
@@ -5,6 +5,6 @@ export function locateEdge(): Promise<string> {
         appName: 'Edge',
         windowsSuffix: '\\Microsoft\\Edge\\Application\\msedge.exe',
         linuxWhich: 'microsoft-edge',
-        // TODO: Is there an macOS and Linux version of Edge?
+         macOsName: 'Microsoft Edge',
     });
 }

--- a/src/browsers/locateInternetExplorer.test.ts
+++ b/src/browsers/locateInternetExplorer.test.ts
@@ -7,7 +7,7 @@ describe('locating the Internet Explorer browser', () => {
                 /iexplore/i,
             );
         } else {
-            await expect(locateInternetExplorer()).rejects.toThrow();
+            await expect(() => locateInternetExplorer()).toThrowError("ie is not available on macOS");
         }
 
         expect.assertions(1);

--- a/src/locateApp.ts
+++ b/src/locateApp.ts
@@ -8,6 +8,8 @@ export interface ILocateAppOptions {
     linuxWhich?: string;
     windowsSuffix?: string;
     macOsName?: string;
+    macOsPackageName?: string;
+    macOsExecName?: string;
 }
 
 export function locateApp({
@@ -15,9 +17,11 @@ export function locateApp({
     linuxWhich,
     windowsSuffix,
     macOsName,
+    macOsPackageName,
+    macOsExecName
 }: RequireAtLeastOne<
     ILocateAppOptions,
-    'linuxWhich' | 'windowsSuffix' | 'macOsName'
+    'linuxWhich' | 'windowsSuffix' | 'macOsName' | 'macOsPackageName' | 'macOsExecName'
 >): Promise<string> {
     if (process.platform === 'win32') {
         if (windowsSuffix) {
@@ -26,8 +30,8 @@ export function locateApp({
             throw new Error(`${appName} is not available on Windows.`);
         }
     } else if (process.platform === 'darwin') {
-        if (macOsName) {
-            return locateAppOnMacOs({ appName, macOsName });
+        if (macOsName !== undefined || macOsPackageName !== undefined || macOsExecName !== undefined)  {
+            return locateAppOnMacOs({ appName, macOsName, macOsPackageName, macOsExecName });
         } else {
             throw new Error(`${appName} is not available on macOS.`);
         }

--- a/src/platforms/locateAppOnMacOs.ts
+++ b/src/platforms/locateAppOnMacOs.ts
@@ -2,6 +2,7 @@
 /// <reference path="./userhome.d.ts" />
 
 import { exec as execLegacy } from 'child_process';
+import { RequireAtLeastOne } from 'type-fest';
 import userhome from 'userhome';
 import { promisify } from 'util';
 import { ILocateAppOptions } from '../locateApp';
@@ -12,12 +13,19 @@ const exec = promisify(execLegacy);
 export async function locateAppOnMacOs({
     appName,
     macOsName,
-}: Pick<
-    Required<ILocateAppOptions>,
-    'appName' | 'macOsName'
->): Promise<string> {
-    const toExec = `/Contents/MacOS/${macOsName}`;
-    const regPath = `/Applications/${macOsName}.app` + toExec;
+    macOsPackageName,
+    macOsExecName,
+}: Pick<Required<ILocateAppOptions>,   'appName' > & Pick<RequireAtLeastOne<ILocateAppOptions>, 'macOsName' | 'macOsPackageName' | 'macOsExecName' >
+    ): Promise<string> {
+ if (!macOsPackageName) {
+  macOsPackageName = macOsName
+ }
+  if (!macOsExecName) {
+  macOsExecName = macOsName
+  }
+
+    const toExec = `/Contents/MacOS/${macOsExecName}`;
+    const regPath = `/Applications/${macOsPackageName}.app` + toExec;
     const altPath = userhome(regPath.slice(1));
 
     if (await isExecutable(regPath)) {

--- a/src/utils/getAppName.test.ts
+++ b/src/utils/getAppName.test.ts
@@ -3,8 +3,8 @@ import { getAppName } from './getAppName';
 
 describe('getting browser name', () => {
     it('should get name of Chrome', async () => {
-        await expect(getAppName(await locateBrowser('chrome'))).resolves.toBe(
-            'Chrome',
+        await expect(getAppName(await locateBrowser('chrome'))).resolves.toMatch(
+            /[cC]hrome/i,
         );
         expect.assertions(1);
     });


### PR DESCRIPTION
MacOs can have different name for package and executable. So introduced additional options: macOsPackageName and macOsExecName

Also make few fixes for unit tests after my changes